### PR TITLE
chore: add Makefile and update docs with make targets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,13 +10,18 @@ Desktop app (PySide6) that generates printable Avery 6427 labels from Scoutbook 
 
 ## Development Commands
 
+A `Makefile` provides all common tasks:
+
 ```bash
-source .venv/bin/activate
-ruff check src/ tests/          # lint
-ruff format src/ tests/         # auto-format
-mypy src/                       # type-check
-python -m pytest --cov=src/core --cov-report=term-missing  # test
-bash scripts/build.sh           # build macOS .app
+make install    # create venv and install deps
+make run        # launch the GUI
+make test       # pytest with coverage (80% gate)
+make lint       # ruff check + format check + mypy
+make format     # auto-format with ruff
+make build      # PyInstaller macOS .app
+make release    # trigger GitHub release workflow
+make clean      # remove build artifacts and caches
+make help       # list all targets
 ```
 
 ## Versioning

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+.PHONY: help install run test lint format build release clean
+
+PYTHON ?= python
+VENV := .venv
+BIN := $(VENV)/bin
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+install: ## Create venv and install dependencies
+	$(PYTHON) -m venv $(VENV)
+	$(BIN)/pip install --upgrade pip
+	$(BIN)/pip install -e ".[dev]"
+
+run: ## Launch the GUI
+	$(BIN)/python -m src.main
+
+test: ## Run tests with coverage (80% gate on src/core)
+	$(BIN)/python -m pytest --cov=src/core --cov-report=term-missing --cov-fail-under=80
+
+lint: ## Run linter, format check, and type checker
+	$(BIN)/ruff check src/ tests/
+	$(BIN)/ruff format --check src/ tests/
+	$(BIN)/mypy src/
+
+format: ## Auto-format code with ruff
+	$(BIN)/ruff format src/ tests/
+	$(BIN)/ruff check --fix src/ tests/
+
+build: ## Build macOS .app with PyInstaller
+	bash scripts/build.sh
+
+release: ## Trigger GitHub release workflow
+	gh workflow run release.yml --repo Jasrags/scout-advancement
+	@echo "Release triggered. Watch with: gh run watch"
+
+clean: ## Remove build artifacts and caches
+	rm -rf build/ dist/ *.egg-info
+	rm -rf .pytest_cache .mypy_cache .ruff_cache .coverage
+	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -8,18 +8,23 @@ Download the latest `.app` from [GitHub Releases](../../releases), unzip, and dr
 
 ## Development Setup
 
-Requires Python 3.10+.
+Requires Python 3.10+ and `make`.
 
 ```bash
-python -m venv .venv
-source .venv/bin/activate
-pip install -e ".[dev]"
+make install    # create venv and install deps
+make run        # launch the GUI
 ```
 
-### Run the GUI
+### Common Commands
 
 ```bash
-python -m src.main
+make test       # run tests with 80% coverage gate
+make lint       # ruff check + format check + mypy
+make format     # auto-format code
+make build      # build macOS .app (output: dist/Scout Advancement Labels.app)
+make release    # trigger GitHub release workflow
+make clean      # remove build artifacts and caches
+make help       # list all targets
 ```
 
 ### Run from CLI (legacy)
@@ -27,22 +32,6 @@ python -m src.main
 ```bash
 python generate_labels_pdf.py <input1.csv> [input2.csv ...] [-o output.pdf]
 ```
-
-### Lint, type-check, and test
-
-```bash
-ruff check src/ tests/
-mypy src/
-python -m pytest --cov=src/core --cov-report=term-missing
-```
-
-### Build macOS .app
-
-```bash
-bash scripts/build.sh
-```
-
-Output: `dist/Scout Advancement Labels.app`
 
 ## CI/CD
 


### PR DESCRIPTION
## Summary
- Add Makefile with targets: install, run, test, lint, format, build, release, clean, help
- Update CLAUDE.md and README.md to reference make commands

No version bump (`chore:` prefix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)